### PR TITLE
Support colon dimension in reshape

### DIFF
--- a/src/compile/convert.jl
+++ b/src/compile/convert.jl
@@ -90,21 +90,19 @@ for (op, xop) in [(+, :Add), (-, :Sub)]
           xcall($xop(), args[2:end]...)
 end
 
-Base.length(s::Shape) = reduce(*, s.size)
-
 @abstract Operations reshape(A::Array{T}, i::NTuple{N,Int}) where {T<:XScalar,N} =
   Shape{Array{T,length(i.value)}}(i.value)
 
 @abstract Operations function reshape(A::Array{T}, i::NTuple{N,Union{Int,Colon}}) where {T<:XScalar,N}
-  dims = Base._reshape_uncolon(A, i.value)
+  dims = Base._reshape_uncolon(Fill(0, size(A)), i.value)
   Shape{Array{T,length(i.value)}}(dims)
 end
 
 xlaop(args, ::AType{typeof(reshape)}, x, sh::Const{NTuple{N,Int}}) where N =
   xcall(Reshape(1:ndims(x), sh.value), args[2])
 
-xlaop(args, ::AType{typeof(reshape)}, x, sh::Const{NTuple{N,Union{Int,Colon}}}) where N =
-  xcall(Reshape(1:ndims(x), Base._reshape_uncolon(x, sh.value)), args[2])
+xlaop(args, ::AType{typeof(reshape)}, x, sh::Const{<:Tuple{Vararg{Union{Int,Colon}}}}) =
+  xcall(Reshape(1:ndims(x), Base._reshape_uncolon(Fill(0, size(x)), sh.value)), args[2])
 
 @abstract Operations getindex(A::Vector{T}, i::Integer) where T<:XScalar = T
 

--- a/src/compile/convert.jl
+++ b/src/compile/convert.jl
@@ -90,11 +90,21 @@ for (op, xop) in [(+, :Add), (-, :Sub)]
           xcall($xop(), args[2:end]...)
 end
 
-@abstract Operations reshape(A::Array{T}, i::Const{NTuple{N,Int}}) where {T<:XScalar,N} =
+Base.length(s::Shape) = reduce(*, s.size)
+
+@abstract Operations reshape(A::Array{T}, i::NTuple{N,Int}) where {T<:XScalar,N} =
   Shape{Array{T,length(i.value)}}(i.value)
 
-xlaop(args, ::AType{typeof(reshape)}, x, sh::Const) =
+@abstract Operations function reshape(A::Array{T}, i::NTuple{N,Union{Int,Colon}}) where {T<:XScalar,N}
+  dims = Base._reshape_uncolon(A, i.value)
+  Shape{Array{T,length(i.value)}}(dims)
+end
+
+xlaop(args, ::AType{typeof(reshape)}, x, sh::Const{NTuple{N,Int}}) where N =
   xcall(Reshape(1:ndims(x), sh.value), args[2])
+
+xlaop(args, ::AType{typeof(reshape)}, x, sh::Const{NTuple{N,Union{Int,Colon}}}) where N =
+  xcall(Reshape(1:ndims(x), Base._reshape_uncolon(x, sh.value)), args[2])
 
 @abstract Operations getindex(A::Vector{T}, i::Integer) where T<:XScalar = T
 

--- a/test/compile.jl
+++ b/test/compile.jl
@@ -123,4 +123,6 @@ sumloop([1, 2, 3])
 let
   f(x) = reshape(x, length(x))
   @test collect(xla(f)([1 2; 3 4])) == [1, 2, 3, 4]
+  g(x) = reshape(x, (5, :))
+  @test size(xla(g)(rand(10, 10))) == (5, 20)
 end


### PR DESCRIPTION
Trying to work through the roadblocks to getting a working `Conv` layer one by one :)

Marked as draft because a) the length declaration should presumably belong in Mjolnir, and b) I'm not sure if calling `_reshape_uncolon` is aboveboard.