### PR TITLE
WIP: Simple Regression with ADAM

### DIFF
--- a/examples/mnist_adam.jl
+++ b/examples/mnist_adam.jl
@@ -1,0 +1,28 @@
+using Flux, Functors, Optimisers, XLA
+using Flux.Data.MNIST
+using Flux: onehotbatch, crossentropy
+
+i = rand(784, 2)
+t = rand(10, 2)
+
+opt = Optimisers.ADAM(0.001, (0.9,0.99))
+
+function step(m)
+  m̄, = gradient(m) do m
+    @show Flux.mse(m(i), t)
+  end
+  return opt2(m, m̄)
+end
+
+m = Chain(Dense(28^2, 32, relu), Dense(32, 10), softmax) |> f64
+
+xstep = xla(step)
+
+function train(m)
+  for _ = 1:100
+    m = xstep(m)
+  end
+  m
+end
+
+train(m)


### PR DESCRIPTION
Using FluxML/Optimisers.jl#3 and simple sketch of a regression task with ADAM

This currently results in 
```
ERROR: Tracing Error: No IR for Tuple{typeof(getfield),Tuple{Int64,Int64},Int64}
in Tuple{typeof(step),Chain{Tuple{Dense{typeof(relu),Array{Float64,2},Array{Float64,1}},Dense{typeof(identity),Array{Float64,2},Array{Float64,1}},typeof(softmax)}}}
in Tuple{typeof(gradient),var"#7#8",Chain{Tuple{Dense{typeof(relu),Array{Float64,2},Array{Float64,1}},Dense{typeof(identity),Array{Float64,2},Array{Float64,1}},typeof(softmax)}}}
in Tuple{Zygote.var"#38#39"{typeof(∂(#7))},Float64}
in Tuple{typeof(∂(#7)),Float64}
in Tuple{typeof(∂(mse)),Float64}
in Tuple{Zygote.var"#3121#back#1219"{Zygote.var"#1215#1217"{Array{Float64,2}}},Float64}
in Tuple{Zygote.var"#1215#1217"{Array{Float64,2}},Float64}
in Tuple{typeof(fill),Float64,Tuple{Int64,Int64}}
in Tuple{Type{Array{Float64,2}},UndefInitializer,Tuple{Int64,Int64}}
in Tuple{typeof(getfield),Tuple{Int64,Int64},Int64}
Stacktrace:
 [1] trace(::Any, ::Any, ::Vararg{Any,N} where N) at /Users/dhairyagandhi/.julia/packages/Mjolnir/eyPSM/src/trace.jl:266
 [2] trace(::Any, ::Vararg{Any,N} where N) at /Users/dhairyagandhi/Downloads/new_clones/XLATools.jl/src/compile/rt.jl:39
 [3] (::XLA.XFunction)(::Any) at /Users/dhairyagandhi/Downloads/new_clones/XLATools.jl/src/compile/rt.jl:55
 [4] train2(::Chain{Tuple{Dense{typeof(relu),Array{Float64,2},Array{Float64,1}},Dense{typeof(identity),Array{Float64,2},Array{Float64,1}},typeof(softmax)}}) at ./REPL[31]:3
 [5] top-level scope at REPL[33]:1
```